### PR TITLE
set composer version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
     composer:
-        image: composer:latest
+        image: composer:2.1.3
         volumes:
             - ${APPLICATION_PATH}:/app
         restart: never


### PR DESCRIPTION
Set the composer version. The docker image says not to rely on the php version... but I did. The latest image was using 7.x and I needed 8. Setting it to use this version it does use 8 though. Not longterm solution for my workflow, but it'll work for now.